### PR TITLE
Make math.cpp methods visible for OptiX

### DIFF
--- a/src/pbrt/gpu/optix/optix.cu
+++ b/src/pbrt/gpu/optix/optix.cu
@@ -25,6 +25,7 @@
 #include <pbrt/util/noise.cpp>
 #include <pbrt/util/spectrum.cpp>
 #include <pbrt/util/transform.cpp>
+#include <pbrt/util/math.cpp>
 
 #include <optix_device.h>
 


### PR DESCRIPTION
Although the new `EarthMedium` volume does not work with Wavefront & GPU, when this code is included in an active GPU compilation produces an undefined symbols error for 'EqualAreaSphereToSquare()' in Optix when a render with VolPtah Integrator is launched. To solve this, I have added 'math.cpp' to the includes in optix.cu